### PR TITLE
cli(update): Fixed latest std version

### DIFF
--- a/eggs/src/commands/update.ts
+++ b/eggs/src/commands/update.ts
@@ -3,7 +3,7 @@
  *     --allow-net, --allow-read, --allow-write
  */
 
-import { Command, existsSync, denoStdLatestVersion } from "../deps.ts";
+import { Command, existsSync } from "../deps.ts";
 const decoder = new TextDecoder("utf-8");
 
 /**
@@ -50,6 +50,13 @@ async function getLatestVersionOfGitHubRepo (owner: string, repo: string): Promi
     const urlSplit = url.split("/");
     const latestRelease = urlSplit[urlSplit.length - 1];
     return latestRelease;
+}
+
+async function getLatestStdVersion (): Promise<string> {
+  const res = await fetch("https://raw.githubusercontent.com/denoland/deno_website2/master/deno_std_versions.json");
+  const versions = await res.json();
+  const latestVersion = versions[0];
+  return latestVersion
 }
 
 /**
@@ -177,7 +184,7 @@ export const update = new Command()
             let latestRelease = "";
             if (line.indexOf("https://deno.land/std") > 0) {
                 // Collate data for std modules
-                latestRelease = denoStdLatestVersion;
+                latestRelease = await getLatestStdVersion();
             }
             if (line.indexOf("https://deno.land/x/") > 0) {
                 // Collate data for deno.land 3rd party modules

--- a/eggs/src/deps.ts
+++ b/eggs/src/deps.ts
@@ -4,7 +4,6 @@ export * as semver from "https://deno.land/x/semver/mod.ts";
 export * as path from "https://deno.land/std/path/mod.ts";
 export { existsSync, expandGlobSync, writeJson } from "https://deno.land/std/fs/mod.ts";
 export { bold, green, yellow, red } from "https://deno.land/std/fmt/colors.ts";
-export { VERSION as denoStdLatestVersion } from "https://deno.land/std@0.56.0/version.ts";
 export { assertEquals } from "https://deno.land/std@v0.56.0/testing/asserts.ts";
 export * as base64 from "https://denopkg.com/chiefbiiko/base64/mod.ts";
 export const lstatSync = Deno.lstatSync;

--- a/eggs/tests/commands/up_to_date_deps.ts
+++ b/eggs/tests/commands/up_to_date_deps.ts
@@ -1,4 +1,4 @@
-import * as colors from "https://deno.land/std@v0.56.0/fmt/colors.ts";
+import * as colors from "https://deno.land/std@v0.57.0/fmt/colors.ts";
 import * as bcrypt from "https://deno.land/x/bcrypt@v0.2.1/mod.ts"
-import * as eggs from "https://x.nest.land/eggs@v0.1.16/mod.ts"
+import * as eggs from "https://x.nest.land/eggs@v0.1.18/mod.ts"
 import * as http from "https://deno.land/std/http/mod.ts" // not versioned for a reason, to ensure we test this case

--- a/eggs/tests/commands/update_test.ts
+++ b/eggs/tests/commands/update_test.ts
@@ -32,7 +32,7 @@ Deno.test({
   //ignore: true,
   async fn(): Promise<void> {
     const p = await Deno.run({
-      cmd: ["deno", "run", "--allow-net", "--allow-read", "--allow-write", "../../src/main.ts", "update", "--deps"],
+      cmd: ["deno", "run", "--allow-net", "--unstable", "--allow-read", "--allow-write", "../../mod.ts", "update", "--deps"],
       stdout: "piped",
       stderr: "piped",
       cwd: "eggs/tests/commands"
@@ -41,8 +41,8 @@ Deno.test({
     p.close();
     const stdout = new TextDecoder("utf-8").decode(await p.output());
     const stderr = new TextDecoder("utf-8").decode(await p.stderrOutput());
-    assertEquals(stderr, "Provide dependencies to update when using --deps. Exiting...\n");
     assertEquals(stdout, "");
+    assertEquals(stderr, "Provide dependencies to update when using --deps. Exiting...\n");
     assertEquals(status.code, 1);
     assertEquals(status.success, false);
     const originalDepContent = new TextDecoder("utf-8").decode(Deno.readFileSync(Deno.cwd() + "/eggs/tests/commands/original_deps.ts"));
@@ -57,7 +57,7 @@ Deno.test({
   //ignore: true,
   async fn(): Promise<void> {
     const p = await Deno.run({
-      cmd: ["deno", "run", "--allow-net", "--allow-read", "--allow-write", "../../src/main.ts", "update", "--file", "deps.ts"],
+      cmd: ["deno", "run", "--allow-net", "--unstable", "--allow-read", "--allow-write", "../../mod.ts", "update", "--file", "deps.ts"],
       stdout: "piped",
       stderr: "piped",
       cwd: "eggs/tests/commands"
@@ -82,7 +82,7 @@ Deno.test({
   //ignore: true,
   async fn(): Promise<void> {
     const p = await Deno.run({
-      cmd: ["deno", "run", "--allow-net", "--allow-read", "--allow-write", "../../src/main.ts", "update"],
+      cmd: ["deno", "run", "--allow-net", "--unstable", "--allow-read", "--allow-write", "../../mod.ts", "update"],
       stdout: "piped",
       stderr: "piped",
       cwd: "eggs/tests/commands"
@@ -98,8 +98,8 @@ Deno.test({
     const originalDepContent = new TextDecoder("utf-8").decode(Deno.readFileSync(Deno.cwd() + "/eggs/tests/commands/original_deps.ts"));
     const newDepContent = new TextDecoder("utf-8").decode(Deno.readFileSync(Deno.cwd() + "/eggs/tests/commands/deps.ts"));
     assertEquals(originalDepContent !== newDepContent, true);
-    assertEquals(newDepContent.indexOf("eggs@v0.1.16") > 0, true);
-    assertEquals(newDepContent.indexOf("std@v0.56.0/fmt") > 0, true);
+    assertEquals(newDepContent.indexOf("eggs@v0.1.18") > 0, true);
+    assertEquals(newDepContent.indexOf("std@v0.57.0/fmt") > 0, true);
     assertEquals(newDepContent.indexOf("bcrypt@v0.2.1") > 0, true);
     replaceMainDepFileContent("deps.ts", "original_deps.ts")
   }
@@ -111,7 +111,7 @@ Deno.test({
   async fn(): Promise<void> {
     removeDependencyFile("deps.ts")
     const p = await Deno.run({
-      cmd: ["deno", "run", "--allow-net", "--allow-read", "--allow-write", "../../src/main.ts", "update", "--file", "dontexist.ts"],
+      cmd: ["deno", "run", "--allow-net", "--unstable", "--allow-read", "--allow-write", "../../mod.ts", "update", "--file", "dontexist.ts"],
       stdout: "piped",
       stderr: "piped",
       cwd: "eggs/tests/commands"
@@ -134,7 +134,7 @@ Deno.test({
   async fn(): Promise<void> {
     emptyDependencyFile("deps.ts")
     const p = await Deno.run({
-      cmd: ["deno", "run", "--allow-net", "--allow-read", "--allow-write", "../../src/main.ts", "update"],
+      cmd: ["deno", "run", "--allow-net", "--unstable", "--allow-read", "--allow-write", "../../mod.ts", "update"],
       stdout: "piped",
       stderr: "piped",
       cwd: "eggs/tests/commands"
@@ -156,9 +156,9 @@ Deno.test({
   name: 'Commands | update | All | Does Nothing If Dependencies Are Up To Date',
   //ignore: true,
   async fn(): Promise<void> {
-    replaceMainDepFileContent("deps.ts", "up_to_date_deps.ts")
+    replaceMainDepFileContent("deps.ts", "up_to_date_deps.ts");
     const p = await Deno.run({
-      cmd: ["deno", "run", "--allow-net", "--allow-read", "--allow-write", "../../src/main.ts", "update"],
+      cmd: ["deno", "run", "--allow-net", "--unstable", "--allow-read", "--allow-write", "../../mod.ts", "update"],
       stdout: "piped",
       stderr: "piped",
       cwd: "eggs/tests/commands"
@@ -181,7 +181,7 @@ Deno.test({
   async fn(): Promise<void> {
     replaceMainDepFileContent("deps.ts", "up_to_date_deps.ts");
     const p = await Deno.run({
-      cmd: ["deno", "run", "--allow-net", "--allow-read", "--allow-write", "../../src/main.ts", "update", "--deps", "http"],
+      cmd: ["deno", "run", "--allow-net", "--unstable", "--allow-read", "--allow-write", "../../mod.ts", "update", "--deps", "http"],
       stdout: "piped",
       stderr: "piped",
       cwd: "eggs/tests/commands"


### PR DESCRIPTION
* Getting the latest std version now actually gets the latest std version without any updates/upgrades

* Fixed all tests to reflect this

**Upgrading Deno**

When an upgrade to deno is made (eg nest.land up's all std versions), the following changes will need to be made:

* `eggs/tests/commands/up_to_date_deps.ts` - Std dependencies would need to be updated

* `eggs/tests/commands/update_test.ts` - Asserted versions for std modules need to be updated

**Other**

* `mod.ts` would need to be cached (`deno cache eggs/mod.ts`) before running the update tests (for example inside of the CI), this is because we would see `Compiling file.../mod.ts` as a part of the stdout, thus failing the first test

* It's possible for tests to fail if 3rd party modules have releases a new version, unfortunately these do need to be tested to test all cases of imports, so it's just something to be wary of if a test fails on a line where it's asserting a certain version of a dependency - the version would just need to be updated in that test case and the `eggs/tests/commands/up_to_date_deps.ts`