### PR TITLE
Feature: optional repository field

### DIFF
--- a/eggs/src/commands/publish.ts
+++ b/eggs/src/commands/publish.ts
@@ -21,6 +21,7 @@ import {
 interface IEggConfig {
   name: string;
   description?: string;
+  repository?: string;
   version?: string;
   stable?: boolean;
 
@@ -46,6 +47,7 @@ export const publish = new Command()
       }
       if (!egg.name) throw new Error(red("You must provide a name for your package!"));
       if (!egg.description) console.log(yellow("You haven't provided a description for your package, continuing without one..."));
+      if (!egg.repository) console.log(yellow("You haven't provided a repository for your package, continuing without one..."));
       if (!egg.version) console.log(yellow("No version found. Generating a new version now..."));
       if (!egg.files) throw new Error(red("No files to upload found. Please see the documentation to add this."));
       if (!egg.files.includes("./README.md")) console.log(yellow("No README found at project root, continuing without one..."));
@@ -95,6 +97,7 @@ export const publish = new Command()
         body: JSON.stringify({
           name: egg.name,
           description: egg.description,
+          repository: egg.repository,
           version: egg.version,
           upload: true,
           latest: true,

--- a/web/src/components/package/PackageDetail.vue
+++ b/web/src/components/package/PackageDetail.vue
@@ -65,6 +65,7 @@
                   <font-awesome-icon class="icon-margin-right" :icon="['fas', 'box-open']" />Package info
                 </p>
                 <div class="panel-block">Author: {{ packageInfo.owner }}</div>
+                <div v-if="packageInfo.repository !== ''" class="panel-block"><a href="{{ packageInfo.repository }}">Repository</a></div>
                 <div class="panel-block">Published on: {{ packageInfo.createdAt | formatDate }}</div>
               </nav>
             </div>

--- a/web/src/components/package/PackageDetail.vue
+++ b/web/src/components/package/PackageDetail.vue
@@ -65,7 +65,7 @@
                   <font-awesome-icon class="icon-margin-right" :icon="['fas', 'box-open']" />Package info
                 </p>
                 <div class="panel-block">Author: {{ packageInfo.owner }}</div>
-                <div v-if="packageInfo.repository !== ''" class="panel-block"><a :href="packageInfo.repository" class="has-text-primary">Repository</a></div>
+                <a class="panel-block" v-if="packageInfo.repository !== ''" :href="packageInfo.repository">Repository</a>
                 <div class="panel-block">Published on: {{ packageInfo.createdAt | formatDate }}</div>
               </nav>
             </div>

--- a/web/src/components/package/PackageDetail.vue
+++ b/web/src/components/package/PackageDetail.vue
@@ -65,7 +65,7 @@
                   <font-awesome-icon class="icon-margin-right" :icon="['fas', 'box-open']" />Package info
                 </p>
                 <div class="panel-block">Author: {{ packageInfo.owner }}</div>
-                <div v-if="packageInfo.repository !== ''" class="panel-block"><a href="{{ packageInfo.repository }}" class="has-text-primary">Repository</a></div>
+                <div v-if="packageInfo.repository !== ''" class="panel-block"><a :href="packageInfo.repository" class="has-text-primary">Repository</a></div>
                 <div class="panel-block">Published on: {{ packageInfo.createdAt | formatDate }}</div>
               </nav>
             </div>

--- a/web/src/components/package/PackageDetail.vue
+++ b/web/src/components/package/PackageDetail.vue
@@ -65,7 +65,7 @@
                   <font-awesome-icon class="icon-margin-right" :icon="['fas', 'box-open']" />Package info
                 </p>
                 <div class="panel-block">Author: {{ packageInfo.owner }}</div>
-                <div v-if="packageInfo.repository !== ''" class="panel-block"><a href="{{ packageInfo.repository }}">Repository</a></div>
+                <div v-if="packageInfo.repository !== ''" class="panel-block"><a href="{{ packageInfo.repository }}" class="has-text-primary">Repository</a></div>
                 <div class="panel-block">Published on: {{ packageInfo.createdAt | formatDate }}</div>
               </nav>
             </div>

--- a/x-node/src/routes/package.ts
+++ b/x-node/src/routes/package.ts
@@ -11,6 +11,7 @@ interface OngoingUpload {
   token: string,
   owner: string,
   description?: string,
+  repository?: string,
   documentation?: string,
   version: string,
   name: string,
@@ -87,11 +88,12 @@ export default (database: DbConnection, arweave: ArwConnection) => {
     let dbUser = await database.repositories.User.findOne({ where: { apiKey: apiKey } });
     if (!dbUser) return res.sendStatus(401);
 
-    let { name, description, documentation, version, latest, stable, upload } = req.body;
+    let { name, description, documentation, repository, version, latest, stable, upload } = req.body;
     if (typeof name !== "string" || name.length > 40) return res.sendStatus(400);
     if (typeof upload !== "undefined" && typeof upload !== "boolean") return res.sendStatus(400);
     if (description && typeof description !== "string") return res.sendStatus(400);
     if (documentation && typeof documentation !== "string") return res.sendStatus(400);
+    if (repository && typeof repository !== "string") return res.sendStatus(400);
     if (version && (typeof version !== "string" || version.length > 20)) return res.sendStatus(400);
 
     if (name.indexOf("@") !== -1 || name.indexOf(" ") !== -1) return res.sendStatus(403);
@@ -136,6 +138,7 @@ export default (database: DbConnection, arweave: ArwConnection) => {
         name: name,
         version: version,
         description: description,
+        repository: repository,
         documentation: documentation,
         latest: latest,
         latestStable: latest && stable,


### PR DESCRIPTION
I started from the thought that if someone wanted to contribute to a package, there was no link to the project repository.
And putting that same link on the README doesn't make sense.

So I think you have to put an optional repository field, which you can configure in the egg.json file.
```json
{
  "name": "remove-forever",
  "description": "Data erasure solution for files on deno 🦕",
  "stable": true,
  "version": "0.1.12",
  "repository": "https://github.com/oganexon/deno-remove-forever",
  "files": [
    "README.md",
    "images/*",
    "mod.ts",
    "cli.ts",
    "lib/*"
  ]
}
```

It would then be visible next to the author field on the package page.
![image](https://user-images.githubusercontent.com/52361520/84590624-89b58e00-ae38-11ea-9d14-b31a7563d0cc.png)

I insist on the fact that I did not go very far in the total functioning of the project and that I could not test this functionality. (And my implementation in the Vue component is probably incorrectly done. I don't know this framework.)

It probably doesn't work, someone needs to review it.