### PR TITLE
[FEATURE] Previous config is used for blank inputs

### DIFF
--- a/eggs/src/commands/init.ts
+++ b/eggs/src/commands/init.ts
@@ -8,7 +8,7 @@ export const init = new Command()
         let previousConfig: Config = {};
 
         if (pathExists("egg.json")) {
-            console.warn(yellow("An egg.json file already exists here! Overriding..."))
+            console.warn(yellow("An egg.json file already exists here! Overriding..."));
             const decoder = new TextDecoder("utf-8");
             const content = decoder.decode(await Deno.readFile("egg.json"));
             previousConfig = JSON.parse(content);

--- a/eggs/src/commands/init.ts
+++ b/eggs/src/commands/init.ts
@@ -5,7 +5,7 @@ export const init = new Command()
     .version("0.1.0")
     .description("Initiates a new package for the nest.land registry.")
     .action(async () => {
-        let previousConfig: Config = {}
+        let previousConfig: Config = {};
 
         if (pathExists("egg.json")) {
             console.warn(yellow("An egg.json file already exists here! Overriding..."))


### PR DESCRIPTION
Fixes #69 

Note: Input can't be blank for `stable` and `name`. Another solution has to be considered.