### PR TITLE
eggs(ci)[test]: fixed CI breaks at PRs by rm it from PRs

### DIFF
--- a/.github/workflows/eggs-test.yml
+++ b/.github/workflows/eggs-test.yml
@@ -1,6 +1,6 @@
 name: Eggs Test
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   build:


### PR DESCRIPTION
Only trigger CI at push and not on PRs for now.