### PR TITLE
quick-fix(eggs): Deno.dir removed from new Deno release

### DIFF
--- a/.github/workflows/eggs-test.yml
+++ b/.github/workflows/eggs-test.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     strategy:
       matrix:

--- a/.github/workflows/eggs-test.yml
+++ b/.github/workflows/eggs-test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        deno-version: [1.1.1]
+        deno-version: [1.1.2]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/eggs-test.yml
+++ b/.github/workflows/eggs-test.yml
@@ -4,11 +4,12 @@ on: [push, pull_request]
 
 jobs:
   build:
-    runs-on: windows-latest
-
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         deno-version: [1.1.2]
+        os: [macOS-latest, windows-latest, ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v2

--- a/eggs/src/utilities/files.ts
+++ b/eggs/src/utilities/files.ts
@@ -1,7 +1,7 @@
 import { path, existsSync } from "../deps.ts";
 
 export function homedir() {
-  return Deno.dir("home") || "/";
+  return Deno.env.get("HOME") || Deno.env.get("HOMEPATH") || Deno.env.get("USERPROFILE") || "/";
 }
 
 export function pathExists(filePath: string) {


### PR DESCRIPTION
This is a quick fix to enable eggs installation on latest Deno version.

Fix #144 