### PR TITLE
CI testing with Deno Nightly builds

### DIFF
--- a/.github/workflows/eggs-test-deno-nightly.yml
+++ b/.github/workflows/eggs-test-deno-nightly.yml
@@ -1,0 +1,38 @@
+name: Eggs Test on Deno Nightly
+
+on: 
+  push:
+    paths:
+      - '.github/workflows/eggs-test-deno-nightly.yml'
+  schedule:
+    - cron: '0 9 * * *'
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macOS-latest, windows-latest, ubuntu-latest]
+
+    steps:
+      - name: Setup Repo
+        uses: actions/checkout@v2
+
+      - name: Setup Deno Nightly (windows)
+        if: startsWith(matrix.os, 'windows')
+        run: iwr https://deno-nightly.now.sh/install.ps1 -useb | iex
+
+      - name: Setup Deno Nightly (mac or linux)
+        if: startsWith(matrix.os, 'mac') || startsWith(matrix.os, 'ubuntu')
+        run: |
+          curl -fsSL https://deno-nightly.now.sh/install.sh | sh
+          echo "::set-env name=DENO_INSTALL::${DENO_INSTALL:-$HOME/.deno}"
+          echo "::add-path::$HOME/.deno/bin"
+
+      - name: Test eggs link
+        run: deno-nightly run --unstable -A eggs/mod.ts link --key ${{ secrets.NESTAPIKEY }}
+
+      - name: Test eggs commands
+        run: deno-nightly test --unstable -A eggs/tests/commands


### PR DESCRIPTION
Create testing workflows to check if eggs is working with the `master` branch of [denoland/deno](https://github.com/denoland/deno)

Deno Nightly repo: [maximousblk/deno_nightly](https://github.com/maximousblk/deno_nightly)