### PR TITLE
fix env for windows install in nightly test CI

### DIFF
--- a/.github/workflows/eggs-test-deno-nightly.yml
+++ b/.github/workflows/eggs-test-deno-nightly.yml
@@ -22,7 +22,10 @@ jobs:
 
       - name: Setup Deno Nightly (windows)
         if: startsWith(matrix.os, 'windows')
-        run: iwr https://deno-nightly.now.sh/install.ps1 -useb | iex
+        run: |
+          iwr https://deno-nightly.now.sh/install.ps1 -useb | iex
+          echo "::set-env name=DENO_INSTALL::${DENO_INSTALL:-$HOME/.deno}"
+          echo "::add-path::$HOME/.deno/bin"
 
       - name: Setup Deno Nightly (mac or linux)
         if: startsWith(matrix.os, 'mac') || startsWith(matrix.os, 'ubuntu')


### PR DESCRIPTION
error:

```
The term 'deno-nightly' is not recognized as the name of a cmdlet, function, script file, or operable program.
```

fix:

set proper environment varables