### PR TITLE
Fix typos

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Following release, we will place a strong emphasis on marketing in order to gain
     - Gallery to view and search packages on the registry (utilizing the API).
   - CLI:
     - User Accounts
-      - A global user account API key will be stored in `~/.nest-land-creds` where the CLI shall retreive them.
+      - A global user account API key will be stored in `~/.nest-land-creds` where the CLI shall retrieve them.
   - API:
     - MongoDB
     - Versions must be SemVer (2.0.0) compliant.

--- a/twig/README.md
+++ b/twig/README.md
@@ -8,7 +8,7 @@ Handle arweave transactions and other functions as an API service.
 
 #### Upload Flow
 
-1. `Rust API` recieves package details and puts its contents in the `tmp` folder.
+1. `Rust API` receives package details and puts its contents in the `tmp` folder.
 
 2. `Twig` gets pinged by the Rust API to process the package contents in `tmp` and upload to the permaweb.
 

--- a/web/src/assets/docs/DOCUMENTATION.md
+++ b/web/src/assets/docs/DOCUMENTATION.md
@@ -167,7 +167,7 @@ eggs update --file file.ts // update all in file.ts
 eggs update --deps http fs // update fs and http in default deps.ts
 ```
 
-More detailed information about this service is avaliable on our CLI [README](https://github.com/nestlandofficial/nest.land/tree/master/eggs).
+More detailed information about this service is available on our CLI [README](https://github.com/nestlandofficial/nest.land/tree/master/eggs).
 
 # Upgrade eggs
 


### PR DESCRIPTION
**Fixed files** :memo: 

```
nest.land/ROADMAP.md:18:97: "retreive" is a misspelling of "retrieve"
nest.land/twig/README.md:11:14: "recieves" is a misspelling of "receives"
nest.land/web/src/assets/docs/DOCUMENTATION.md:170:48: "avaliable" is a misspelling of "available"
```