### PR TITLE
changed og image config

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -11,26 +11,26 @@
   <!-- Search Engine -->
   <meta name="description" content="An immutable, blockchain powered module registry for Deno.">
   <meta name="image"
-    content="https://og.nest.land/**nest**.land.jpeg?theme=light&md=1&fontSize=125px&images=https%3A%2F%2Fnest.land%2Fimages%2Fnest.land%2Flogo_light.svg">
+    content="https://og.nest.land/.png?fontSize=350px">
   <meta name="title" content="nest.land">
   <meta name="robots" content="index, follow">
   <!-- Schema.org for Google -->
   <meta itemprop="name" content="nest.land">
   <meta itemprop="description" content="An immutable, blockchain powered module registry for Deno.">
   <meta itemprop="image"
-    content="https://og.nest.land/**nest**.land.jpeg?theme=light&md=1&fontSize=125px&images=https%3A%2F%2Fnest.land%2Fimages%2Fnest.land%2Flogo_light.svg">
+    content="https://og.nest.land/.png?fontSize=350px">
   <!-- Twitter -->
   <meta name="twitter:card" content="summary">
   <meta name="twitter:title" content="nest.land">
   <meta name="twitter:description" content="An immutable, blockchain powered module registry for Deno.">
   <meta name="twitter:creator" content="@tateberenbaum">
   <meta name="twitter:image:src"
-    content="https://og.nest.land/**nest**.land.jpeg?theme=light&md=1&fontSize=125px&images=https%3A%2F%2Fnest.land%2Fimages%2Fnest.land%2Flogo_light.svg">
+    content="https://og.nest.land/.png?fontSize=350px">
   <!-- Open Graph general (Facebook, Pinterest & Google+) -->
   <meta name="og:title" content="nest.land">
   <meta name="og:description" content="An immutable, blockchain powered module registry for Deno.">
   <meta name="og:image"
-    content="https://og.nest.land/**nest**.land.jpeg?theme=light&md=1&fontSize=125px&images=https%3A%2F%2Fnest.land%2Fimages%2Fnest.land%2Flogo_light.svg">
+    content="https://og.nest.land/.png?fontSize=350px">
   <meta name="og:site_name" content="nest.land">
   <meta name="og:locale" content="en_US">
   <meta name="og:type" content="website">


### PR DESCRIPTION
currently the og image is

![https://og.nest.land/**nest**.land.jpeg?theme=light&md=1&fontSize=125px&images=https%3A%2F%2Fnest.land%2Fimages%2Fnest.land%2Flogo_light.svg](https://og.nest.land/**nest**.land.jpeg?theme=light&md=1&fontSize=125px&images=https%3A%2F%2Fnest.land%2Fimages%2Fnest.land%2Flogo_light.svg)

which would translate to nest.land / nest.land

new og image is

![https://og.nest.land/.png?fontSize=350px](https://og.nest.land/.png?fontSize=350px)

which would translate to nest.land and is also similar to the [older og image](https://github.com/nestlandofficial/nest.land/blob/master/web/public/social_preview.jpg)